### PR TITLE
Cisco IOS XR use snmpwalk

### DIFF
--- a/funcs/swifstat.go
+++ b/funcs/swifstat.go
@@ -160,7 +160,7 @@ func coreSwIfMetrics(ip string, ch chan ChIfStat, limitCh chan bool) {
 		var err error
 
 		vendor, _ := sw.SysVendor(ip, community, snmpTimeout)
-		if vendor == "Huawei" {
+		if vendor == "Huawei" || vendor == "Cisco_IOS_XR" {
 			ifList, err = sw.ListIfStatsSnmpWalk(ip, community, snmpTimeout*5, ignoreIface, snmpRetry, ignorePkt)
 		} else {
 			ifList, err = sw.ListIfStats(ip, community, snmpTimeout, ignoreIface, snmpRetry, ignorePkt)


### PR DESCRIPTION
测试里似乎ASR9K用源生的snmp读取接口数据也不太正常。
参照华为，采取snmpwalk方式~
