### PR TITLE
Add Cisco ASA ConnectionStat，displayByBit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * CPU利用率
 * 内存利用率
 * Ping延时
+* 网络连接数（监控防火墙时，目前仅支持Cisco ASA)
 * IfHCInOctets
 * IfHCOutOctets
 * IfHCInUcastPkts
@@ -21,6 +22,10 @@ CPU和内存的OID私有，根据设备厂家和OS版本可能不同。目前测
 
 * Cisco IOS(Version 12)
 * Cisco NX-OS(Version 6)
+* Cisco IOS XR(Version 5)
+* Cisco IOS XE(Version 15)
+* Cisco ASA (Version 9)
+* Ruijie 10G Routing Switch
 * Huawei VRP(Version 8)
 * H3C(Version 5)
 * H3C(Version 7)
@@ -40,6 +45,8 @@ swcollector需要部署到有交换机SNMP访问权限的服务器上。
 使用Go原生的ICMP协议进行Ping探测，swcollector需要root权限运行。
 
 Huawei交换机使用Go原生SNMP协议会报超时或乱序错误。暂时解决方法是SNMP接口流量查询前先判断设备型号，对Huawei设备，调用snmpwalk命令进行数据收集。
+Cisco IOS XR使用源生SNMP也有些问题，亦采用snmpwalk来解决问题
+因此如果监控以上型号的交换机，需要在监控探针服务器上安装snmpwalk命令
 
 
 ##配置说明
@@ -61,7 +68,8 @@ switch配置项说明：
 		"snmpTimeout":1000,				#SNMP超时时间，单位毫秒
 		"snmpRetry":5,					#SNMP重试次数
 		"ignoreIface": ["Nu","NU","Vlan","Vl"],    #忽略的接口，如Nu匹配ifName为*Nu*的接口
-		"ignorePkt": true,            #不采集IfHCInUcastPkts和IfHCOutUcastPkts		
+		"ignorePkt": true,            #不采集IfHCInUcastPkts和IfHCOutUcastPkts
+		"displayByBit": true,		  #true时，上报的流量单位为bit，为false则单位为byte。		
  		"limitConcur": 1000           #限制SNMP请求并发数
     }
 

--- a/cfg.example.json
+++ b/cfg.example.json
@@ -16,6 +16,7 @@
 		"snmpRetry":5,
 		"ignoreIface": ["Nu","NU","Vlan","Vl"],
 		"ignorePkt": true,
+		"displayByBit": true,
 		"limitConcur": 1000
  	}, 
     "heartbeat": {

--- a/cron/builtin.go
+++ b/cron/builtin.go
@@ -1,7 +1,7 @@
 package cron
 
 import (
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"log"
 	"strconv"

--- a/cron/collector.go
+++ b/cron/collector.go
@@ -1,8 +1,8 @@
 package cron
 
 import (
-	"github.com/gaochao1/swcollector/funcs"
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/funcs"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"log"
 	"math"

--- a/cron/ips.go
+++ b/cron/ips.go
@@ -1,7 +1,7 @@
 package cron
 
 import (
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"log"
 	"time"

--- a/cron/reporter.go
+++ b/cron/reporter.go
@@ -2,7 +2,7 @@ package cron
 
 import (
 	"fmt"
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"log"
 	"time"

--- a/funcs/common.go
+++ b/funcs/common.go
@@ -1,7 +1,7 @@
 package funcs
 
 import (
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"strings"
 )

--- a/funcs/funcs.go
+++ b/funcs/funcs.go
@@ -1,7 +1,7 @@
 package funcs
 
 import (
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 )
 
@@ -22,6 +22,7 @@ func BuildMappers() {
 				CpuMetrics,
 				MemMetrics,
 				PingMetrics,
+				ConnMetrics,
 			},
 			Interval: interval,
 		},

--- a/funcs/swconn.go
+++ b/funcs/swconn.go
@@ -35,6 +35,7 @@ func connMetrics(ip string, ch chan SwConn) {
 	var swConn SwConn
 	vendor, _ := sw.SysVendor(ip, community, snmpTimeout)
 	if vendor != "Cisco_ASA"{
+		ch <- swConn
 		return
 	}
 	ConnectionStat, err := sw.ConnectionStat(ip, g.Config().Switch.Community, g.Config().Switch.SnmpTimeout, g.Config().Switch.SnmpRetry)

--- a/funcs/swconn.go
+++ b/funcs/swconn.go
@@ -1,0 +1,50 @@
+package funcs
+
+import (
+	"github.com/freedomkk-qfeng/sw"
+	"github.com/freedomkk-qfeng/swcollector/g"
+	"github.com/open-falcon/common/model"
+	"log"
+	"time"
+)
+
+type SwConn struct {
+	Ip       string
+	ConnectionStat int
+}
+
+func ConnMetrics() (L []*model.MetricValue) {
+
+	chs := make([]chan SwConn, len(AliveIp))
+	for i, ip := range AliveIp {
+		if ip != "" {
+			chs[i] = make(chan SwConn)
+			go connMetrics(ip, chs[i])
+		}
+	}
+
+	for _, ch := range chs {
+		swConn := <-ch
+		L = append(L, GaugeValueIp(time.Now().Unix(), swConn.Ip, "switch.ConnectionStat", swConn.ConnectionStat))
+	}
+
+	return L
+}
+
+func connMetrics(ip string, ch chan SwConn) {
+	var swConn SwConn
+	vendor, _ := sw.SysVendor(ip, community, snmpTimeout)
+	if vendor != "Cisco_ASA"{
+		return
+	}
+	ConnectionStat, err := sw.ConnectionStat(ip, g.Config().Switch.Community, g.Config().Switch.SnmpTimeout, g.Config().Switch.SnmpRetry)
+	if err != nil {
+		log.Println(err)
+	}
+
+	swConn.Ip = ip
+	swConn.ConnectionStat = ConnectionStat
+	ch <- swConn
+
+	return
+}

--- a/funcs/swcpu.go
+++ b/funcs/swcpu.go
@@ -1,8 +1,8 @@
 package funcs
 
 import (
-	"github.com/gaochao1/sw"
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/sw"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"log"
 	"time"

--- a/funcs/swifstat.go
+++ b/funcs/swifstat.go
@@ -1,11 +1,11 @@
 package funcs
 
 import (
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"log"
 
-	"github.com/gaochao1/sw"
+	"github.com/freedomkk-qfeng/sw"
 	"github.com/toolkits/slice"
 
 	"strconv"
@@ -101,10 +101,14 @@ func swIfMetrics() (L []*model.MetricValue) {
 				ifNameTag := "ifName=" + ifStat.IfName
 				ifIndexTag := "ifIndex=" + strconv.Itoa(ifStat.IfIndex)
 				ip := chIfStat.Ip
-
-				L = append(L, CounterValueIp(ifStat.TS, ip, "switch.if.In", ifStat.IfHCInOctets, ifNameTag, ifIndexTag))
-				L = append(L, CounterValueIp(ifStat.TS, ip, "switch.if.Out", ifStat.IfHCOutOctets, ifNameTag, ifIndexTag))
-
+				if g.Config().Switch.DisplayByBit == true {
+					L = append(L, CounterValueIp(ifStat.TS, ip, "switch.if.In", 8*ifStat.IfHCInOctets, ifNameTag, ifIndexTag))
+					L = append(L, CounterValueIp(ifStat.TS, ip, "switch.if.Out", 8*ifStat.IfHCOutOctets, ifNameTag, ifIndexTag))
+				}else{
+					L = append(L, CounterValueIp(ifStat.TS, ip, "switch.if.In", ifStat.IfHCInOctets, ifNameTag, ifIndexTag))
+					L = append(L, CounterValueIp(ifStat.TS, ip, "switch.if.Out", ifStat.IfHCOutOctets, ifNameTag, ifIndexTag))
+	
+				}
 				//如果IgnorePkt为false，采集Pkt
 				if g.Config().Switch.IgnorePkt == false {
 					L = append(L, CounterValueIp(ifStat.TS, ip, "switch.if.InPkts", ifStat.IfHCInUcastPkts, ifNameTag, ifIndexTag))

--- a/funcs/swmem.go
+++ b/funcs/swmem.go
@@ -1,8 +1,8 @@
 package funcs
 
 import (
-	"github.com/gaochao1/sw"
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/sw"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"log"
 	"time"

--- a/funcs/swping.go
+++ b/funcs/swping.go
@@ -1,8 +1,8 @@
 package funcs
 
 import (
-	"github.com/gaochao1/sw"
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/sw"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"log"
 	"time"

--- a/funcs/swsystem.go
+++ b/funcs/swsystem.go
@@ -1,8 +1,8 @@
 package funcs
 
 import (
-	"github.com/gaochao1/sw"
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/sw"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"log"
 )
 
@@ -14,6 +14,7 @@ type SwSystem struct {
 	Cpu      int    `json:"cpu"`
 	Mem      int    `json:"mem"`
 	Ping     string `json:"ping"`
+	Conn	 int	`json:"Conn"`
 }
 
 func SwSystemInfo() (swList []SwSystem) {

--- a/g/cfg.go
+++ b/g/cfg.go
@@ -22,6 +22,7 @@ type SwitchConfig struct {
 
 	IgnoreIface []string `json:"ignoreIface"`
 	IgnorePkt   bool     `json:"ignorePkt"`
+	DisplayByBit bool	 `json:"displayByBit"`
 	LimitConcur int      `json:"limitConcur"`
 }
 

--- a/g/const.go
+++ b/g/const.go
@@ -7,7 +7,8 @@ import (
 // changelog:
 // 3.1.3: code refactor
 // 3.1.4: bugfix ignore configuration
+// 3.1.5: more sw support, DisplayByBit cfg
 const (
-	VERSION          = "3.1.4"
+	VERSION          = "3.1.5"
 	COLLECT_INTERVAL = time.Second
 )

--- a/http/admin.go
+++ b/http/admin.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/toolkits/file"
 	"net/http"
 	"os"

--- a/http/health.go
+++ b/http/health.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"net/http"
 )
 

--- a/http/http.go
+++ b/http/http.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"encoding/json"
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"log"
 	"net/http"
 	_ "net/http/pprof"

--- a/http/page.go
+++ b/http/page.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/toolkits/file"
 	"net/http"
 	"path/filepath"

--- a/http/push.go
+++ b/http/push.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"encoding/json"
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/open-falcon/common/model"
 	"net/http"
 )

--- a/http/run.go
+++ b/http/run.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"github.com/toolkits/sys"
 	"io/ioutil"
 	"net/http"

--- a/http/sw.go
+++ b/http/sw.go
@@ -2,8 +2,8 @@ package http
 
 import (
 	"fmt"
-	"github.com/gaochao1/swcollector/funcs"
-	"github.com/gaochao1/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/funcs"
+	"github.com/freedomkk-qfeng/swcollector/g"
 	"net/http"
 	"strings"
 	"time"

--- a/main.go
+++ b/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/gaochao1/swcollector/cron"
-	"github.com/gaochao1/swcollector/funcs"
-	"github.com/gaochao1/swcollector/g"
-	"github.com/gaochao1/swcollector/http"
+	"github.com/freedomkk-qfeng/swcollector/cron"
+	"github.com/freedomkk-qfeng/swcollector/funcs"
+	"github.com/freedomkk-qfeng/swcollector/g"
+	"github.com/freedomkk-qfeng/swcollector/http"
 	"os"
 )
 


### PR DESCRIPTION
增加对防火墙的支持，监控防火墙时，上报连接数（Cisco ASA）
配置文件增加一个displayByBit，为true时上报的interace接口流量数据*8，即以bit为单位上报。
这样展示出来的流量更符合网络监控的习惯。
